### PR TITLE
Add disclaimer about the status of the repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,13 @@
 
 [![Stability: Experimental](https://masterminds.github.io/stability/experimental.svg)](https://masterminds.github.io/stability/experimental.html)
 
-> **DISCLAIMER:** This repository was forked from [Adven27/grpc-wiremock](https://github.com/Adven27/grpc-wiremock) which was archived by the maintainer.
-> This fork is used to preserve the repository, and to make it available for experimental use and contributions.
-> See [wiremock/wiremock #2148](https://github.com/wiremock/wiremock/issues/2148) for the feature request about providing an officially supported implementation
-> (or updating this one)
+> **WARNING:** There is a new official [gRPC extension for WireMock](https://github.com/wiremock/wiremock-grpc-extension) under active development.
+> The extension allows implementing proper matching and gRPC-specific functionality, instead of just using a converter bridge.
+> We are looking for feedback and contributions!
+> See [wiremock/wiremock #2148](https://github.com/wiremock/wiremock/issues/2148) for the feature request about providing an officially supported implementation.
+> 
+> **CREDITS:** This repository was forked from [Adven27/grpc-wiremock](https://github.com/Adven27/grpc-wiremock) which was archived by the maintainer.
+> This fork is used to preserve the repository, and to make it available for experimental use.
 
 _grpc-wiremock_ is a **mock server** for **GRPC** services implemented as a wrapper around the [WireMock](https://wiremock.org) HTTP server.
 It is implementated in Java and runs as a standalone proxy container.


### PR DESCRIPTION
Some polishing for https://github.com/wiremock/wiremock/issues/2148

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [ ] Recommended: If you participate in Hacktoberfest 2023, maake sure you're [signed up](https://wiremock.org/events/hacktoberfest/) there and in the WireMock form 
- [ ] The PR request is well described and justified, including the body and the references
- [ ] The PR title represents the desired changelog entry
- [ ] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
